### PR TITLE
Tolerate two subnets and Introduce Cleanup command

### DIFF
--- a/gitpod-network-check/README.md
+++ b/gitpod-network-check/README.md
@@ -17,7 +17,7 @@ A CLI to check if your network setup is suitable for the installation of Gitpod.
    ```
 
 2. Set up AWS credentials
-   
+
    `gitpod-network-check` needs access to the AWS account you are planning to use to deploy Gitpod in. Much like AWS CLI, `gitpod-network-check` uses the available AWS profile in your terminal to authenticate against the account. This means that you can rely on any locally available [AWS profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) or just set the right environment variables in your terminal for the CLI to use:
    ```
    export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
@@ -44,7 +44,7 @@ A CLI to check if your network setup is suitable for the installation of Gitpod.
 
    To start the diagnosis, the the command: `./gitpod-network-check diagnose`
 
-   ```
+   ```console
    ./gitpod-network-check diagnose
    INFO[0000] ✅ Main Subnets are valid
    INFO[0000] ✅ Pod Subnets are valid
@@ -77,3 +77,18 @@ A CLI to check if your network setup is suitable for the installation of Gitpod.
    INFO[0191] ✅ S3 is available
    ```
 
+3. Clean up after network diagnosis
+
+   Dianosis is designed to do clean-up before it finishes. However, if the process terminates unexpectedly, you may clean-up AWS resources it creates like so:
+
+   ```console
+   ./gitpod-network-check clean
+   INFO[0000] ✅ Main Subnets are valid
+   INFO[0000] ✅ Pod Subnets are valid
+   INFO[0000] ✅ Instances terminated
+   INFO[0000] Cleaning up: Waiting for 2 minutes so network interfaces are deleted
+   INFO[0121] ✅ Role 'GitpodNetworkCheck' deleted
+   INFO[0121] ✅ Instance profile deleted
+   INFO[0122] ✅ Security group 'sg-0a6119dcb6a564fc1' deleted
+   INFO[0122] ✅ Security group 'sg-07373362953212e54' deleted
+   ```

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -302,6 +302,17 @@ func launchInstanceInSubnet(ctx context.Context, ec2Client *ec2.Client, subnetID
 		IamInstanceProfile: &types.IamInstanceProfileSpecification{
 			Arn: instanceProfileName,
 		},
+		TagSpecifications: []types.TagSpecification{
+			{
+				ResourceType: types.ResourceTypeInstance,
+				Tags: []types.Tag{
+					{
+						Key:   aws.String("gitpod.io/network-check"),
+						Value: aws.String("true"),
+					},
+				},
+			},
+		},
 	}
 
 	var result *ec2.RunInstancesOutput
@@ -440,6 +451,17 @@ func createSecurityGroups(ctx context.Context, svc *ec2.Client, subnetID string)
 		Description: aws.String("EC2 security group allowing all HTTPS outgoing traffic"),
 		GroupName:   aws.String(fmt.Sprintf("EC2-security-group-nc-%s", subnetID)),
 		VpcId:       vpcID,
+		TagSpecifications: []types.TagSpecification{
+			{
+				ResourceType: types.ResourceTypeInstance,
+				Tags: []types.Tag{
+					{
+						Key:   aws.String("gitpod.io/network-check"),
+						Value: aws.String("true"),
+					},
+				},
+			},
+		},
 	}
 
 	createSGOutput, err := svc.CreateSecurityGroup(ctx, createSGInput)

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -453,7 +453,7 @@ func createSecurityGroups(ctx context.Context, svc *ec2.Client, subnetID string)
 		VpcId:       vpcID,
 		TagSpecifications: []types.TagSpecification{
 			{
-				ResourceType: types.ResourceTypeInstance,
+				ResourceType: types.ResourceTypeSecurityGroup,
 				Tags: []types.Tag{
 					{
 						Key:   aws.String("gitpod.io/network-check"),

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -270,6 +270,9 @@ func launchInstances(ctx context.Context, ec2Client *ec2.Client, subnets []strin
 		}
 
 		instanceIds = append(instanceIds, instanceId)
+		if Subnets == nil {
+			Subnets = make(map[string]bool)
+		}
 		Subnets[subnet] = true
 	}
 

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -49,6 +49,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 			return fmt.Errorf("❌ error creating IAM role and attaching policy: %v", err)
 		}
 		Roles = append(Roles, *role.RoleName)
+		log.Info("✅ IAM role created and policy attached")
 
 		instanceProfile, err := createInstanceProfileAndAttachRole(cmd.Context(), iamClient, *role.RoleName)
 		if err != nil {
@@ -60,7 +61,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		slices.Sort(allSubnets)
 		distinctSubnets := slices.Compact(allSubnets)
 		if len(distinctSubnets) < len(allSubnets) {
-			log.Info("ℹ️  Found duplicate subnets. We'll test each subnet only once, starting with main.")
+			log.Infof("ℹ️  Found duplicate subnets. We'll test each subnet '%v' only once.", distinctSubnets)
 		}
 
 		log.Infof("ℹ️  Launching EC2 instances in Main subnets")
@@ -256,7 +257,7 @@ func launchInstances(ctx context.Context, ec2Client *ec2.Client, subnets []strin
 	var instanceIds []string
 	for _, subnet := range subnets {
 		if _, ok := Subnets[subnet]; ok {
-			log.Warnf("Subnet '%v' was already launched, skipping", subnet)
+			log.Warnf("An EC2 instance was already created for subnet '%v', skipping", subnet)
 			continue
 		}
 		secGroup, err := createSecurityGroups(ctx, ec2Client, subnet)

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -470,7 +470,7 @@ func createSecurityGroups(ctx context.Context, svc *ec2.Client, subnetID string)
 	}
 
 	sgID := createSGOutput.GroupId
-	log.Infof("ℹ️ Created security group with ID: %s", *sgID)
+	log.Infof("ℹ️  Created security group with ID: %s", *sgID)
 
 	// Authorize HTTPS outbound traffic
 	authorizeEgressInput := &ec2.AuthorizeSecurityGroupEgressInput{

--- a/gitpod-network-check/cmd/cleanup.go
+++ b/gitpod-network-check/cmd/cleanup.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/spf13/cobra"
+)
+
+var cleanCommand = &cobra.Command{ // nolint:gochecknoglobals
+	PersistentPreRunE: validateSubnets,
+	Use:               "clean",
+	Short:             "Explicitly cleans up after the network check diagnosis",
+	SilenceUsage:      false,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := initAwsConfig(cmd.Context(), networkConfig.AwsRegion)
+		if err != nil {
+			return err
+		}
+
+		ec2Client := ec2.NewFromConfig(cfg)
+		iamClient := iam.NewFromConfig(cfg)
+
+		cleanup(cmd.Context(), ec2Client, iamClient)
+		return nil
+	},
+}

--- a/gitpod-network-check/cmd/common.go
+++ b/gitpod-network-check/cmd/common.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iam_types "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	log "github.com/sirupsen/logrus"
@@ -18,6 +19,7 @@ var (
 	SecurityGroups  []string
 	Roles           []string
 	InstanceProfile string
+	Subnets         map[string]bool
 )
 
 const gitpodRoleName = "GitpodNetworkCheck"
@@ -35,6 +37,24 @@ func initAwsConfig(ctx context.Context, region string) (aws.Config, error) {
 }
 
 func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
+	if len(InstanceIds) == 0 {
+		instances, err := svc.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+			Filters: []types.Filter{
+				{
+					Name:   aws.String("tag:gitpod.io/network-check"),
+					Values: []string{"true"},
+				},
+			},
+		})
+		if err != nil {
+			log.WithError(err).Warn("Failed to list instances, please cleanup manually")
+		}
+
+		for _, i := range instances.Reservations[0].Instances {
+			InstanceIds = append(InstanceIds, *i.InstanceId)
+		}
+	}
+
 	if len(InstanceIds) > 0 {
 		_, err := svc.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 			InstanceIds: InstanceIds,
@@ -42,7 +62,33 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 		if err != nil {
 			log.WithError(err).WithField("instanceIds", InstanceIds).Warnf("Failed to cleanup instances, please cleanup manually")
 		}
+
+		log.Info("✅ Instances terminated")
 	}
+
+	if len(Roles) == 0 {
+		roles, err := iamsvc.ListRoles(ctx, &iam.ListRolesInput{
+			PathPrefix: aws.String("/GitpodNetworkCheck"),
+		})
+		if err != nil {
+			log.WithError(err).Warn("Failed to list roles, please cleanup manually")
+		}
+
+		for _, role := range roles.Roles {
+			if role.RoleName == nil {
+				continue
+			}
+
+			if *role.RoleName == gitpodRoleName {
+				Roles = append(Roles, *role.RoleName)
+			}
+		}
+	}
+
+	if InstanceProfile == "" {
+		InstanceProfile = gitpodInstanceProfile
+	}
+
 	if len(Roles) > 0 {
 		for _, role := range Roles {
 			_, err := iamsvc.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"), RoleName: aws.String(role)})
@@ -61,7 +107,10 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 			_, err = iamsvc.DeleteRole(ctx, &iam.DeleteRoleInput{RoleName: aws.String(role)})
 			if err != nil {
 				log.WithError(err).WithField("rolename", role).Warnf("Failed to cleanup role, please cleanup manaullay")
+				continue
 			}
+
+			log.Infof("✅ Role '%v' deleted", role)
 		}
 
 		_, err := iamsvc.DeleteInstanceProfile(ctx, &iam.DeleteInstanceProfileInput{
@@ -71,10 +120,31 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 		if err != nil {
 			log.WithError(err).WithField("instanceProfile", InstanceProfile).Warnf("Failed to clean up instance profile, please cleanup manually")
 		}
+
+		log.Info("✅ Instance profile deleted")
 	}
 
 	log.Info("Cleaning up: Waiting for 1 minute so network interfaces are deleted")
 	time.Sleep(time.Minute)
+
+	if len(SecurityGroups) == 0 {
+		securityGroups, err := svc.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			Filters: []types.Filter{
+				{
+					Name:   aws.String("tag:gitpod.io/network-check"),
+					Values: []string{"true"},
+				},
+			},
+		})
+
+		if err != nil {
+			log.WithError(err).Error("Failed to list security groups, please cleanup manually")
+		}
+
+		for _, sg := range securityGroups.SecurityGroups {
+			SecurityGroups = append(SecurityGroups, *sg.GroupId)
+		}
+	}
 
 	if len(SecurityGroups) > 0 {
 		for _, sg := range SecurityGroups {
@@ -85,9 +155,9 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 			_, err := svc.DeleteSecurityGroup(ctx, deleteSGInput)
 			if err != nil {
 				log.WithError(err).WithField("securityGroup", sg).Warnf("Failed to clean up security group, please cleanup manually")
+				continue
 			}
-
+			log.Infof("✅ Security group '%v' deleted", sg)
 		}
-
 	}
 }

--- a/gitpod-network-check/cmd/common.go
+++ b/gitpod-network-check/cmd/common.go
@@ -48,10 +48,14 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 		})
 		if err != nil {
 			log.WithError(err).Warn("Failed to list instances, please cleanup manually")
+		} else if len(instances.Reservations) == 0 {
+			log.Info("No instances found.")
 		}
 
-		for _, i := range instances.Reservations[0].Instances {
-			InstanceIds = append(InstanceIds, *i.InstanceId)
+		for _, r := range instances.Reservations {
+			for _, i := range r.Instances {
+				InstanceIds = append(InstanceIds, *i.InstanceId)
+			}
 		}
 	}
 
@@ -72,6 +76,8 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 		})
 		if err != nil {
 			log.WithError(err).Warn("Failed to list roles, please cleanup manually")
+		} else if len(roles.Roles) == 0 {
+			log.Info("No roles found.")
 		}
 
 		for _, role := range roles.Roles {
@@ -139,6 +145,8 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 
 		if err != nil {
 			log.WithError(err).Error("Failed to list security groups, please cleanup manually")
+		} else if len(securityGroups.SecurityGroups) == 0 {
+			log.Info("No security groups found.")
 		}
 
 		for _, sg := range securityGroups.SecurityGroups {

--- a/gitpod-network-check/cmd/common.go
+++ b/gitpod-network-check/cmd/common.go
@@ -64,9 +64,6 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 	}
 
 	if len(InstanceIds) > 0 {
-		log.Info("Cleaning up: Waiting for 2 minutes so network interfaces are deleted")
-		time.Sleep(2 * time.Minute)
-
 		_, err := svc.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 			InstanceIds: InstanceIds,
 		})
@@ -75,6 +72,9 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 		}
 
 		log.Info("✅ Instances terminated")
+
+		log.Info("Cleaning up: Waiting for 2 minutes so network interfaces are deleted")
+		time.Sleep(2 * time.Minute)
 	}
 
 	if len(Roles) == 0 {

--- a/gitpod-network-check/cmd/common.go
+++ b/gitpod-network-check/cmd/common.go
@@ -64,8 +64,8 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 	}
 
 	if len(InstanceIds) > 0 {
-		log.Info("Cleaning up: Waiting for 1 minute so network interfaces are deleted")
-		time.Sleep(time.Minute)
+		log.Info("Cleaning up: Waiting for 2 minutes so network interfaces are deleted")
+		time.Sleep(2 * time.Minute)
 
 		_, err := svc.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 			InstanceIds: InstanceIds,
@@ -98,6 +98,9 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 					}
 				}
 			}
+		}
+		if len(Roles) == 0 {
+			log.Info("No roles found.")
 		}
 	}
 

--- a/gitpod-network-check/cmd/common.go
+++ b/gitpod-network-check/cmd/common.go
@@ -60,6 +60,9 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 	}
 
 	if len(InstanceIds) > 0 {
+		log.Info("Cleaning up: Waiting for 1 minute so network interfaces are deleted")
+		time.Sleep(time.Minute)
+
 		_, err := svc.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 			InstanceIds: InstanceIds,
 		})
@@ -129,9 +132,6 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 
 		log.Info("✅ Instance profile deleted")
 	}
-
-	log.Info("Cleaning up: Waiting for 1 minute so network interfaces are deleted")
-	time.Sleep(time.Minute)
 
 	if len(SecurityGroups) == 0 {
 		securityGroups, err := svc.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{

--- a/gitpod-network-check/cmd/common.go
+++ b/gitpod-network-check/cmd/common.go
@@ -44,6 +44,10 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 					Name:   aws.String("tag:gitpod.io/network-check"),
 					Values: []string{"true"},
 				},
+				{
+					Name:   aws.String("instance-state-name"),
+					Values: []string{"pending", "running", "shutting-down", "stopping", "stopped"},
+				},
 			},
 		})
 		if err != nil {

--- a/gitpod-network-check/cmd/common.go
+++ b/gitpod-network-check/cmd/common.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iam_types "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	log "github.com/sirupsen/logrus"
+)
+
+// this will be useful when we are cleaning up things at the end
+var (
+	InstanceIds     []string
+	SecurityGroups  []string
+	Roles           []string
+	InstanceProfile string
+)
+
+const gitpodRoleName = "GitpodNetworkCheck"
+const gitpodInstanceProfile = "GitpodNetworkCheck"
+
+var networkCheckTag = []iam_types.Tag{
+	{
+		Key:   aws.String("gitpod.io/network-check"),
+		Value: aws.String("true"),
+	},
+}
+
+func initAwsConfig(ctx context.Context, region string) (aws.Config, error) {
+	return config.LoadDefaultConfig(ctx, config.WithRegion(region))
+}
+
+func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
+	if len(InstanceIds) > 0 {
+		_, err := svc.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
+			InstanceIds: InstanceIds,
+		})
+		if err != nil {
+			log.WithError(err).WithField("instanceIds", InstanceIds).Warnf("Failed to cleanup instances, please cleanup manually")
+		}
+	}
+	if len(Roles) > 0 {
+		for _, role := range Roles {
+			_, err := iamsvc.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{PolicyArn: aws.String("arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"), RoleName: aws.String(role)})
+			if err != nil {
+				log.WithError(err).WithField("rolename", role).Warnf("Failed to cleanup role, please cleanup manually")
+			}
+
+			_, err = iamsvc.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{
+				RoleName:            aws.String(role),
+				InstanceProfileName: aws.String(InstanceProfile),
+			})
+			if err != nil {
+				log.WithError(err).WithField("roleName", role).WithField("profileName", InstanceProfile).Warnf("Failed to remove role from instance profile")
+			}
+
+			_, err = iamsvc.DeleteRole(ctx, &iam.DeleteRoleInput{RoleName: aws.String(role)})
+			if err != nil {
+				log.WithError(err).WithField("rolename", role).Warnf("Failed to cleanup role, please cleanup manaullay")
+			}
+		}
+
+		_, err := iamsvc.DeleteInstanceProfile(ctx, &iam.DeleteInstanceProfileInput{
+			InstanceProfileName: aws.String(InstanceProfile),
+		})
+
+		if err != nil {
+			log.WithError(err).WithField("instanceProfile", InstanceProfile).Warnf("Failed to clean up instance profile, please cleanup manually")
+		}
+	}
+
+	log.Info("Cleaning up: Waiting for 1 minute so network interfaces are deleted")
+	time.Sleep(time.Minute)
+
+	if len(SecurityGroups) > 0 {
+		for _, sg := range SecurityGroups {
+			deleteSGInput := &ec2.DeleteSecurityGroupInput{
+				GroupId: aws.String(sg),
+			}
+
+			_, err := svc.DeleteSecurityGroup(ctx, deleteSGInput)
+			if err != nil {
+				log.WithError(err).WithField("securityGroup", sg).Warnf("Failed to clean up security group, please cleanup manually")
+			}
+
+		}
+
+	}
+}

--- a/gitpod-network-check/cmd/root.go
+++ b/gitpod-network-check/cmd/root.go
@@ -126,5 +126,6 @@ func readConfigFile() *viper.Viper {
 
 func Execute() error {
 	networkCheckCmd.AddCommand(checkCommand)
+	networkCheckCmd.AddCommand(cleanCommand)
 	return networkCheckCmd.Execute()
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Some customers reuse subnets, but when this happens, it causes the checker to fail (because the security group already exists).

Also, while troubleshooting, I noticed that we're not tagging related resources, which makes it difficult to find and delete them later on.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-473

## How to test
<!-- Provide steps to test this PR -->

Setup a YAML file like so:
```yaml
log-level: debug # Options: debug, info, warning, error
region: eu-central-1
main-subnets: subnet-0c2be6925d464ae0e, subnet-0ac7749ca3d2337b2
pod-subnets: subnet-0c2be6925d464ae0e, subnet-0ac7749ca3d2337b2
```

And then:
1. `go run . diagnose` to test
2. See that maybe some resources need to be cleaned up manually (like below, security groups lingered)
3. `go run . clean` to find and remove lingering test resources

```bash
# run diagnose
gitpod /workspace/enterprise-deployment-toolkit/gitpod-network-check (kylos101/tolerate-duplicate-subnets) $ go run . diagnose
INFO[0000] ✅ Main Subnets are valid                     
INFO[0000] ✅ Pod Subnets are valid                      
INFO[0000] ℹ️  Checking prerequisites                   
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ec2messages is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ssm is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ssmmessages is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.execute-api is configured 
INFO[0001] ℹ️  Found duplicate subnets. We'll test each subnet only once, starting with main. 
INFO[0001] ℹ️  Launching EC2 instances in Main subnets  
INFO[0001] ℹ️  Created security group with ID: sg-0f28e2365912b13c3 
INFO[0008] ℹ️  Created security group with ID: sg-0a7ce352a5ef827d1 
INFO[0010] ℹ️  Launching EC2 instances in a Pod subnets 
WARN[0010] Subnet 'subnet-0c2be6925d464ae0e' was already launched, skipping 
WARN[0010] Subnet ' subnet-0ac7749ca3d2337b2' was already launched, skipping 
INFO[0010] ℹ️  Waiting for EC2 instances to become ready (can take up to 2 minutes) 
INFO[0035] ✅ EC2 Instances are now running successfully 
INFO[0035] ℹ️  Connecting to SSM...                     
INFO[0118] ℹ️  Checking if the required AWS Services can be reached from the ec2 instances 
INFO[0118] ✅ Autoscaling is available                   
INFO[0119] ✅ CloudFormation is available                
INFO[0119] ✅ CloudWatch is available                    
INFO[0120] ✅ EC2 is available                           
INFO[0121] ✅ EC2messages is available                   
INFO[0121] ✅ ECR is available                           
INFO[0122] ✅ ECR Api is available                       
INFO[0123] ✅ EKS is available                           
INFO[0124] ✅ Elastic LoadBalancing is available         
INFO[0124] ✅ KMS is available                           
INFO[0125] ✅ Kinesis Firehose is available              
INFO[0126] ✅ SSM is available                           
INFO[0126] ✅ SSMmessages is available                   
INFO[0127] ✅ SecretsManager is available                
INFO[0128] ✅ Sts is available                           
INFO[0128] ✅ DynamoDB is available                      
INFO[0129] ✅ S3 is available                            
INFO[0129] Cleaning up: Waiting for 2 minutes so network interfaces are deleted 
INFO[0249] ✅ Instances terminated                       
INFO[0250] ✅ Role 'GitpodNetworkCheck' deleted          
INFO[0250] ✅ Instance profile deleted                   
WARN[0250] Failed to clean up security group, please cleanup manually  error="operation error EC2: DeleteSecurityGroup, https response error StatusCode: 400, RequestID: 772c9f27-db47-4966-965f-9d9ed2f70771, api error DependencyViolation: resource sg-0f28e2365912b13c3 has a dependent object" securityGroup=sg-0f28e2365912b13c3
WARN[0251] Failed to clean up security group, please cleanup manually  error="operation error EC2: DeleteSecurityGroup, https response error StatusCode: 400, RequestID: 1c2b3d0d-b617-4e5b-bacb-de6958ec7cdf, api error DependencyViolation: resource sg-0a7ce352a5ef827d1 has a dependent object" securityGroup=sg-0a7ce352a5ef827d1

# run clean to find and remove left behind resources
gitpod /workspace/enterprise-deployment-toolkit/gitpod-network-check (kylos101/tolerate-duplicate-subnets) $ go run . clean
INFO[0000] ✅ Main Subnets are valid                     
INFO[0000] ✅ Pod Subnets are valid                      
INFO[0000] No instances found.                          
INFO[0000] No roles found.                              
INFO[0000] ✅ Security group 'sg-0f28e2365912b13c3' deleted 
INFO[0001] ✅ Security group 'sg-0a7ce352a5ef827d1' deleted 

# run clean again, to assert everything is gone.
gitpod /workspace/enterprise-deployment-toolkit/gitpod-network-check (kylos101/tolerate-duplicate-subnets) $ go run . clean
INFO[0000] ✅ Main Subnets are valid                     
INFO[0000] ✅ Pod Subnets are valid                      
INFO[0000] No instances found.                          
INFO[0000] No roles found.                              
INFO[0000] No security groups found. 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
