### PR TITLE
Tolerate https scheme & update docs

### DIFF
--- a/gitpod-network-check/README.md
+++ b/gitpod-network-check/README.md
@@ -100,3 +100,74 @@ A CLI to check if your network setup is suitable for the installation of Gitpod.
    INFO[0122] ✅ Security group 'sg-0a6119dcb6a564fc1' deleted
    INFO[0122] ✅ Security group 'sg-07373362953212e54' deleted
    ```
+
+## FAQ
+
+If the EC2 instances are timing out, or you cannot connect to them with Session Manager, be sure to add the following policies.
+
+For the ssm vpc endpoint, add the following policy:
+
+```json
+{
+   "Effect": "Allow",
+   "Action": [
+      "*"
+   ],
+   "Resource": [
+      "*"
+   ],
+   "Principal": {
+      "AWS": [
+         "*"
+      ]
+   },
+   "Condition": {
+      "ArnEquals": {
+         "aws:PrincipalArn": "arn:aws:iam::<aws-account-id>:role/GitpodNetworkCheck"
+      }
+   }
+},
+{
+   "Effect": "Allow",
+   "Action": [
+      "*"
+   ],
+   "Resource": [
+      "*"
+   ],
+   "Principal": {
+      "AWS": [
+         "*"
+      ]
+   },
+   "Condition": {
+      "StringEquals": {
+         "ec2:InstanceProfile": "arn:aws:iam::<aws-account-id>:instance-profile/GitpodNetworkCheck"
+      }
+   }
+}
+```
+
+For the ec2messages and ssmmessages vpc endpoints, add the following policy:
+
+```json
+{
+   "Effect": "Allow",
+   "Action": [
+      "*"
+   ],
+   "Resource": [
+      "*"
+   ],
+   "Principal": {
+      "AWS": [
+         "*"
+      ]
+   },
+   "Condition": {
+      "ArnEquals": {
+         "aws:PrincipalArn": "arn:aws:iam::<aws-account-id>:role/GitpodNetworkCheck"
+      }
+   }
+}
+```

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -139,7 +139,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 			if parsedUrl.Scheme == "" {
 				httpHosts[host] = fmt.Sprintf("https://%s", host)
 			} else if parsedUrl.Scheme == "https" {
-				httpHosts[host] = host
+				httpHosts[host] = parsedUrl.Host
 			} else {
 				log.Warnf("🚧 Unsupported scheme: %s, skipping test for %s", parsedUrl.Scheme, host)
 				continue

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -129,7 +130,20 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		httpHosts := map[string]string{}
 		for _, v := range networkConfig.HttpsHosts {
 			host := strings.TrimSpace(v)
-			httpHosts[host] = fmt.Sprintf("https://%s", host)
+			parsedUrl, err := url.Parse(host)
+			if err != nil {
+				log.Warnf("🚧 Invalid Host: %s, skipping due to error: %v", host, err)
+				continue
+			}
+
+			if parsedUrl.Scheme == "" {
+				httpHosts[host] = fmt.Sprintf("https://%s", host)
+			} else if parsedUrl.Scheme == "https" {
+				httpHosts[host] = host
+			} else {
+				log.Warnf("🚧 Unsupported scheme: %s, skipping test for %s", parsedUrl.Scheme, host)
+				continue
+			}
 		}
 		if len(httpHosts) > 0 {
 			log.Infof("ℹ️  Checking if hosts can be reached with HTTPS from ec2 instances in the main subnets")

--- a/gitpod-network-check/gitpod-network-check.yaml
+++ b/gitpod-network-check/gitpod-network-check.yaml
@@ -1,5 +1,5 @@
 log-level: debug # Options: debug, info, warning, error
 region: eu-central-1
-main-subnets: subnet-0a195092eb78c7674, subnet-05db6651c2ef39639
-pod-subnets: subnet-00a5f0d10253fb33c, subnet-09f658fd789fc9b84
-https-hosts: accounts.google.com, github.com
+main-subnets: subnet-017c6a80f4879d851, subnet-0215744d52cd1c01f
+pod-subnets: subnet-00a118009d1d572a5, subnet-062288af00ba50d86
+https-hosts: accounts.google.com, https://github.com


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Tolerate users encountering with scheme or not, but only support https scheme (ignore others).

Also, updated the documentation after testing in a private cell that was built using our latest infrastructure (where we limit the VPC endpoints). Otherwise gitpod-network-check will fail.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-630

## How to test
<!-- Provide steps to test this PR -->

1. Test with unsupported schemes

```
go run . diagnose
INFO[0000] ✅ Main Subnets are valid                     
INFO[0000] ✅ Pod Subnets are valid                      
INFO[0000] ℹ️  Checking prerequisites                   
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ec2messages is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ssm is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ssmmessages is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.execute-api is configured 
INFO[0000] ✅ IAM role created and policy attached       
INFO[0001] ℹ️  Launching EC2 instances in Main subnets  
INFO[0001] ℹ️  Created security group with ID: sg-0fbbf79f1d4749ece 
INFO[0008] ℹ️  Created security group with ID: sg-09cf8f40133a248b7 
INFO[0010] ℹ️  Main EC2 instances: [i-045e426b72b43d9f0 i-0ec28f9c96ca805ce] 
INFO[0010] ℹ️  Launching EC2 instances in a Pod subnets 
INFO[0010] ℹ️  Created security group with ID: sg-07991bf2e32482c40 
INFO[0013] ℹ️  Created security group with ID: sg-09f06096305c1d743 
INFO[0015] ℹ️  Pod EC2 instances: [i-0c24d97271ebf7783 i-034e332706fbfe246] 
INFO[0015] ℹ️  Waiting for EC2 instances to become ready (can take up to 2 minutes) 
INFO[0047] ✅ EC2 Instances are now running successfully 
INFO[0047] ℹ️  Connecting to SSM...                     
INFO[0123] ℹ️  Checking if the required AWS Services can be reached from the ec2 instances 
INFO[0124] ✅ Autoscaling is available                   
INFO[0125] ✅ CloudFormation is available                
INFO[0126] ✅ CloudWatch is available                    
INFO[0127] ✅ EC2 is available                           
INFO[0128] ✅ EC2messages is available                   
INFO[0130] ✅ ECR is available                           
INFO[0130] ✅ ECR Api is available                       
INFO[0131] ✅ EKS is available                           
INFO[0132] ✅ Elastic LoadBalancing is available         
INFO[0134] ✅ KMS is available                           
INFO[0135] ✅ Kinesis Firehose is available              
INFO[0136] ✅ SSM is available                           
INFO[0137] ✅ SSMmessages is available                   
INFO[0138] ✅ SecretsManager is available                
INFO[0139] ✅ Sts is available                           
INFO[0139] ℹ️  Checking if certain AWS Services can be reached from ec2 instances in the main subnet 
INFO[0140] ✅ DynamoDB is available                      
INFO[0142] ✅ S3 is available                            
WARN[0142] 🚧 Unsupported scheme: httpx, skipping test for  httpx://gitpod.io 
WARN[0142] 🚧 Unsupported scheme: http, skipping test for  http://aol.com 
INFO[0142] ℹ️  Checking if hosts can be reached with HTTPS from ec2 instances in the main subnets 
INFO[0143] ✅ accounts.google.com is available           
INFO[0144] ✅ github.com is available                    
INFO[0145] ✅ https://okta.com is available              
INFO[0145] ✅ Instances terminated                       
INFO[0145] Cleaning up: Waiting for 2 minutes so network interfaces are deleted 
INFO[0266] ✅ Role 'GitpodNetworkCheck' deleted          
INFO[0266] ✅ Instance profile deleted                   
INFO[0267] ✅ Security group 'sg-0fbbf79f1d4749ece' deleted 
INFO[0267] ✅ Security group 'sg-09cf8f40133a248b7' deleted 
INFO[0267] ✅ Security group 'sg-07991bf2e32482c40' deleted 
INFO[0267] ✅ Security group 'sg-09f06096305c1d743' deleted 
```

2. Test with supported schemes only

```
go run . diagnose
INFO[0000] ✅ Main Subnets are valid                     
INFO[0000] ✅ Pod Subnets are valid                      
INFO[0000] ℹ️  Checking prerequisites                   
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ec2messages is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ssm is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.ssmmessages is configured 
INFO[0000] ✅ VPC endpoint com.amazonaws.eu-central-1.execute-api is configured 
INFO[0000] ✅ IAM role created and policy attached       
INFO[0001] ℹ️  Launching EC2 instances in Main subnets  
INFO[0001] ℹ️  Created security group with ID: sg-0306785da84886870 
INFO[0007] ℹ️  Created security group with ID: sg-0799a09b016272637 
INFO[0009] ℹ️  Main EC2 instances: [i-062a3b4b79864ae3c i-0f22ea05add71fd21] 
INFO[0009] ℹ️  Launching EC2 instances in a Pod subnets 
INFO[0010] ℹ️  Created security group with ID: sg-0bd7cb9de2b5bbed8 
INFO[0012] ℹ️  Created security group with ID: sg-0246627980b8b50e5 
INFO[0014] ℹ️  Pod EC2 instances: [i-0532caaae32e9c615 i-0ed8eedf443da1281] 
INFO[0014] ℹ️  Waiting for EC2 instances to become ready (can take up to 2 minutes) 
INFO[0043] ✅ EC2 Instances are now running successfully 
INFO[0043] ℹ️  Connecting to SSM...                     
INFO[0117] ℹ️  Checking if the required AWS Services can be reached from the ec2 instances 
INFO[0118] ✅ Autoscaling is available                   
INFO[0119] ✅ CloudFormation is available                
INFO[0120] ✅ CloudWatch is available                    
INFO[0122] ✅ EC2 is available                           
INFO[0123] ✅ EC2messages is available                   
INFO[0124] ✅ ECR is available                           
INFO[0125] ✅ ECR Api is available                       
INFO[0126] ✅ EKS is available                           
INFO[0127] ✅ Elastic LoadBalancing is available         
INFO[0128] ✅ KMS is available                           
INFO[0130] ✅ Kinesis Firehose is available              
INFO[0131] ✅ SSM is available                           
INFO[0132] ✅ SSMmessages is available                   
INFO[0133] ✅ SecretsManager is available                
INFO[0134] ✅ Sts is available                           
INFO[0134] ℹ️  Checking if certain AWS Services can be reached from ec2 instances in the main subnet 
INFO[0135] ✅ DynamoDB is available                      
INFO[0136] ✅ S3 is available                            
INFO[0136] ℹ️  Checking if hosts can be reached with HTTPS from ec2 instances in the main subnets 
INFO[0137] ✅ accounts.google.com is available           
INFO[0139] ✅ https://github.com is available            
INFO[0139] ✅ Instances terminated                       
INFO[0139] Cleaning up: Waiting for 2 minutes so network interfaces are deleted 
INFO[0260] ✅ Role 'GitpodNetworkCheck' deleted          
INFO[0260] ✅ Instance profile deleted                   
INFO[0260] ✅ Security group 'sg-0306785da84886870' deleted 
INFO[0261] ✅ Security group 'sg-0799a09b016272637' deleted 
INFO[0261] ✅ Security group 'sg-0bd7cb9de2b5bbed8' deleted 
INFO[0261] ✅ Security group 'sg-0246627980b8b50e5' deleted 
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
