### PR TITLE
[diagnose] test service connectivity when no VPC endpoint exists 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Enterprise Deployment Toolkit",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/go": {
+      "version": "1.22.0"
+    }
+  },
+  "remoteEnv": {
+    "GIT_EDITOR": "code --wait"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "golang.go",
+        "zxh404.vscode-proto3"
+      ]
+    }
+  }
+}

--- a/.gitpod/automations.yaml
+++ b/.gitpod/automations.yaml
@@ -1,12 +1,12 @@
 tasks:
-  buildProject:
+  goBuild:
     name: Build project
     command: cd gitpod-network-check && go build ./...
     triggeredBy:
       - manual
       - postEnvironmentStart
 
-  runTests:
+  goTest:
     name: Run tests
     command: cd gitpod-network-check && go test -v ./...
     triggeredBy:

--- a/.gitpod/automations.yaml
+++ b/.gitpod/automations.yaml
@@ -1,0 +1,14 @@
+tasks:
+  buildProject:
+    name: Build project
+    command: cd gitpod-network-check && go build ./...
+    triggeredBy:
+      - manual
+      - postEnvironmentStart
+
+  runTests:
+    name: Run tests
+    command: cd gitpod-network-check && go test -v ./...
+    triggeredBy:
+      - manual
+      - postEnvironmentStart

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -157,6 +157,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 type vpcEndpointsMap struct {
 	Endpoint string
 	Required bool
+	PrivateDnsRequired bool
 }
 
 // the ssm-agent requires that ec2messages, ssm and ssmmessages are available
@@ -168,18 +169,22 @@ func checkSMPrerequisites(ctx context.Context, ec2Client *ec2.Client) error {
 		{
 			Endpoint: fmt.Sprintf("com.amazonaws.%s.ec2messages", networkConfig.AwsRegion),
 			Required: false,
+			PrivateDnsRequired: false,
 		},
 		{
 			Endpoint: fmt.Sprintf("com.amazonaws.%s.ssm", networkConfig.AwsRegion),
 			Required: false,
+			PrivateDnsRequired: false,
 		},
 		{
 			Endpoint: fmt.Sprintf("com.amazonaws.%s.ssmmessages", networkConfig.AwsRegion),
 			Required: false,
+			PrivateDnsRequired: false,
 		},
 		{
 			Endpoint: fmt.Sprintf("com.amazonaws.%s.execute-api", networkConfig.AwsRegion),
 			Required: true,
+			PrivateDnsRequired: true,
 		},
 	}
 
@@ -204,7 +209,7 @@ func checkSMPrerequisites(ctx context.Context, ec2Client *ec2.Client) error {
 			log.Infof("ℹ️  VPC endpoint %s is not configured", endpoint.Endpoint)
 		} else {
 			for _, e := range response.VpcEndpoints {
-				if e.PrivateDnsEnabled != nil && !*e.PrivateDnsEnabled {
+				if e.PrivateDnsEnabled != nil && !*e.PrivateDnsEnabled && endpoint.PrivateDnsRequired {
 					log.Errorf("❌ VPC endpoint '%s' has private DNS disabled, it must be enabled", *e.VpcEndpointId)
 				}
 			}

--- a/gitpod-network-check/cmd/root.go
+++ b/gitpod-network-check/cmd/root.go
@@ -24,6 +24,7 @@ type NetworkConfig struct {
 	PodSubnets  []string
 	HttpsHosts  []string
 	InstanceAMI string
+	ApiEndpoint string
 }
 
 var networkConfig = NetworkConfig{LogLevel: "INFO"}
@@ -91,6 +92,7 @@ func init() {
 	networkCheckCmd.PersistentFlags().StringSliceVar(&networkConfig.HttpsHosts, "https-hosts", []string{}, "Hosts to test for outbound HTTPS connectivity")
 	bindFlags(networkCheckCmd, v)
 	networkCheckCmd.PersistentFlags().StringVar(&networkConfig.InstanceAMI, "instance-ami", "", "Custom ec2 instance AMI id, if not set will use latest ubuntu")
+	networkCheckCmd.PersistentFlags().StringVar(&networkConfig.ApiEndpoint, "api-endpoint", "", "The Gitpod Enterprise control plane's regional API endpoint subdomain")
 	log.Infof("ℹ️  Running with region `%s`, main subnet `%v`, pod subnet `%v`, and hosts `%v`", networkConfig.AwsRegion, networkConfig.MainSubnets, networkConfig.PodSubnets, networkConfig.HttpsHosts)
 }
 

--- a/gitpod-network-check/cmd/root.go
+++ b/gitpod-network-check/cmd/root.go
@@ -90,10 +90,10 @@ func init() {
 	networkCheckCmd.PersistentFlags().StringSliceVar(&networkConfig.MainSubnets, "main-subnets", []string{}, "List of main subnets")
 	networkCheckCmd.PersistentFlags().StringSliceVar(&networkConfig.PodSubnets, "pod-subnets", []string{}, "List of pod subnets")
 	networkCheckCmd.PersistentFlags().StringSliceVar(&networkConfig.HttpsHosts, "https-hosts", []string{}, "Hosts to test for outbound HTTPS connectivity")
-	bindFlags(networkCheckCmd, v)
 	networkCheckCmd.PersistentFlags().StringVar(&networkConfig.InstanceAMI, "instance-ami", "", "Custom ec2 instance AMI id, if not set will use latest ubuntu")
 	networkCheckCmd.PersistentFlags().StringVar(&networkConfig.ApiEndpoint, "api-endpoint", "", "The Gitpod Enterprise control plane's regional API endpoint subdomain")
-	log.Infof("ℹ️  Running with region `%s`, main subnet `%v`, pod subnet `%v`, and hosts `%v`", networkConfig.AwsRegion, networkConfig.MainSubnets, networkConfig.PodSubnets, networkConfig.HttpsHosts)
+	bindFlags(networkCheckCmd, v)
+	log.Infof("ℹ️  Running with region `%s`, main subnet `%v`, pod subnet `%v`, hosts `%v`, and api endpoint `%v`", networkConfig.AwsRegion, networkConfig.MainSubnets, networkConfig.PodSubnets, networkConfig.HttpsHosts, networkConfig.ApiEndpoint)
 }
 
 func readConfigFile() *viper.Viper {

--- a/gitpod-network-check/gitpod-network-check.yaml
+++ b/gitpod-network-check/gitpod-network-check.yaml
@@ -1,7 +1,8 @@
 log-level: debug # Options: debug, info, warning, error
 region: eu-central-1
-main-subnets: subnet-017c6a80f4879d851, subnet-0215744d52cd1c01f
-pod-subnets: subnet-00a118009d1d572a5, subnet-062288af00ba50d86
+main-subnets: subnet-03ed4c7f3f10ee64a, subnet-03ae0d9e3ad063d83
+pod-subnets: subnet-09704642a44a1ae9b, subnet-0fc43a731956656cd
 https-hosts: accounts.google.com, https://github.com
 # put your custom ami id here if you want to use it, otherwise it will using latest ubuntu AMI from aws
 instance-ami:
+api-endpoint: 6v268t83fd

--- a/gitpod-network-check/gitpod-network-check.yaml
+++ b/gitpod-network-check/gitpod-network-check.yaml
@@ -5,4 +5,4 @@ pod-subnets: subnet-09704642a44a1ae9b, subnet-0fc43a731956656cd
 https-hosts: accounts.google.com, https://github.com
 # put your custom ami id here if you want to use it, otherwise it will using latest ubuntu AMI from aws
 instance-ami:
-api-endpoint: 6v268t83fd
+api-endpoint:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Provide a means to test connectivity for AWS services when the current VPC lacks VPC endpoints. For example, perhaps [VPC endpoints are centralized in another VPC](https://docs.aws.amazon.com/whitepapers/latest/building-scalable-secure-multi-vpc-network-infrastructure/centralized-access-to-vpc-private-endpoints.html).

Background:
There are two sets of checks in the network check CLI
1. What VPC endpoints the CLI needs + the execute-api endpoint (so we can inspect the setting for private DNS )
   * it tries inspecting VPC endpoints in the same account (this is existing and slightly changed)
   * if the VPC endpoints don't exist, we degrade and assert service name resolution and connectivity (this is new)
2. The balance of tests assert other AWS services that Gitpod needs
   * it creates EC2 instances, and uses SSM to send curl requests (from ec2 instance in particular subnets) to each AWS service (this is unchanged)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1118

## How to test
<!-- Provide steps to test this PR -->
1. Setup a network using our public networking template
4. Delete the execute-api endpoint
5. Run diagnose, it should fail for the execute-api endpoint, the other check should pass. ([results](https://github.com/gitpod-io/enterprise-deployment-toolkit/pull/12#issuecomment-2628494975))

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
