### PR TITLE
[checks] make api-endpoint parameter optional & update usage docs

### DIFF
--- a/gitpod-network-check/README.md
+++ b/gitpod-network-check/README.md
@@ -44,6 +44,7 @@ A CLI to check if your network setup is suitable for the installation of Gitpod.
    pod-subnets: subnet-028d11dce93b8eefc, subnet-04ec8257d95c434b7,subnet-00a83550ce709f39c
    https-hosts: accounts.google.com, github.com
    instance-ami: # put your custom ami id here if you want to use it, otherwise it will using latest ubuntu AMI from aws
+   api-endpoint: # optional, put your API endpoint regional sub-domain here to test connectivity, like when the execute-api vpc endpoint is not in the same account as Gitpod 
    ```
 
    note: if using a custom AMI, please ensure the [SSM agent](https://docs.aws.amazon.com/systems-manager/latest/userguide/manually-install-ssm-agent-linux.html) and [curl](https://curl.se/) are both installed. We rely on SSM's [SendCommand](https://docs.aws.amazon.com/code-library/latest/ug/ssm_example_ssm_SendCommand_section.html) to test HTTPS connectivity.

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -66,10 +66,6 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 			log.Infof("ℹ️  Found duplicate subnets. We'll test each subnet '%v' only once.", distinctSubnets)
 		}
 
-		if networkConfig.ApiEndpoint == "" {
-			return fmt.Errorf("❌ API endpoint is required")
-		}
-
 		log.Infof("ℹ️  Launching EC2 instances in Main subnets")
 		mainInstanceIds, err := launchInstances(cmd.Context(), ec2Client, networkConfig.MainSubnets, instanceProfile.Arn)
 		if err != nil {
@@ -127,9 +123,11 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 
 		log.Infof("ℹ️  Checking if certain AWS Services can be reached from ec2 instances in the main subnet")
 		serviceEndpointsForMain := map[string]string{
-			"S3":         fmt.Sprintf("https://s3.%s.amazonaws.com", networkConfig.AwsRegion),
-			"DynamoDB":   fmt.Sprintf("https://dynamodb.%s.amazonaws.com", networkConfig.AwsRegion),
-			"ExecuteAPI": fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com", networkConfig.ApiEndpoint, networkConfig.AwsRegion),
+			"S3":       fmt.Sprintf("https://s3.%s.amazonaws.com", networkConfig.AwsRegion),
+			"DynamoDB": fmt.Sprintf("https://dynamodb.%s.amazonaws.com", networkConfig.AwsRegion),
+		}
+		if networkConfig.ApiEndpoint != "" {
+			serviceEndpointsForMain["ExecuteAPI"] = fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com", networkConfig.ApiEndpoint, networkConfig.AwsRegion)
 		}
 		checkServicesAvailability(cmd.Context(), ssmClient, mainInstanceIds, serviceEndpointsForMain)
 

--- a/gitpod-network-check/gitpod-network-check.yaml
+++ b/gitpod-network-check/gitpod-network-check.yaml
@@ -5,4 +5,5 @@ pod-subnets: subnet-09704642a44a1ae9b, subnet-0fc43a731956656cd
 https-hosts: accounts.google.com, https://github.com
 # put your custom ami id here if you want to use it, otherwise it will using latest ubuntu AMI from aws
 instance-ami:
+# optional, put your API endpoint regional sub-domain here to test connectivity, like when the execute-api vpc endpoint is not in the same account as Gitpod 
 api-endpoint:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
It is only necessary for customers to specify a value for api-endpoint when the VPC endpoints are not in the same account as Gitpod.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1118

## How to test
<!-- Provide steps to test this PR -->
Test w/o api-endpoint param, it should not be included in the results for the main subnet
Test w/ api-endpoint param, it should be included in the results for the main subnet
See test results (below)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
