### PR TITLE
Fail if execute-api service is insufficient

### DIFF
--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -91,7 +91,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		if err != nil {
 			return fmt.Errorf("❌ Nodes never got Running: %v", err)
 		}
-		log.Info("✅  EC2 instances are now Running.")
+		log.Info("✅ EC2 instances are now Running.")
 		log.Info("ℹ️  Waiting for EC2 instances to become Healthy (times out in 5 minutes)")
 		waitstatusOK := ec2.NewInstanceStatusOkWaiter(ec2Client, func(isow *ec2.InstanceStatusOkWaiterOptions) {
 			isow.MaxDelay = 15 * time.Second

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -82,16 +82,16 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		log.Infof("ℹ️  Pod EC2 instances: %v", podInstanceIds)
 		InstanceIds = append(InstanceIds, podInstanceIds...)
 
-		log.Info("ℹ️  Waiting for EC2 instances to become Running (times out in 4 minutes)")
+		log.Info("ℹ️  Waiting for EC2 instances to become Running (times out in 5 minutes)")
 		runningWaiter := ec2.NewInstanceRunningWaiter(ec2Client, func(irwo *ec2.InstanceRunningWaiterOptions) {
 			irwo.MaxDelay = 15 * time.Second
 			irwo.MinDelay = 5 * time.Second
 		})
-		err = runningWaiter.Wait(cmd.Context(), &ec2.DescribeInstancesInput{InstanceIds: InstanceIds}, *aws.Duration(4 * time.Minute))
+		err = runningWaiter.Wait(cmd.Context(), &ec2.DescribeInstancesInput{InstanceIds: InstanceIds}, *aws.Duration(5 * time.Minute))
 		if err != nil {
 			return fmt.Errorf("❌ Nodes never got Running: %v", err)
 		}
-		log.Info("ℹ️  EC2 instances are now Running.")
+		log.Info("✅  EC2 instances are now Running.")
 		log.Info("ℹ️  Waiting for EC2 instances to become Healthy (times out in 5 minutes)")
 		waitstatusOK := ec2.NewInstanceStatusOkWaiter(ec2Client, func(isow *ec2.InstanceStatusOkWaiterOptions) {
 			isow.MaxDelay = 15 * time.Second
@@ -101,7 +101,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		if err != nil {
 			return fmt.Errorf("❌ Nodes never got Healthy: %v", err)
 		}
-		log.Info("✅ EC2 Instances are now healthy/Ok")
+		log.Info("✅  EC2 Instances are now healthy/Ok")
 
 		log.Infof("ℹ️  Connecting to SSM...")
 		err = ensureSessionManagerIsUp(cmd.Context(), ssmClient)

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -101,7 +101,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		if err != nil {
 			return fmt.Errorf("❌ Nodes never got Healthy: %v", err)
 		}
-		log.Info("✅  EC2 Instances are now healthy/Ok")
+		log.Info("✅ EC2 Instances are now healthy/Ok")
 
 		log.Infof("ℹ️  Connecting to SSM...")
 		err = ensureSessionManagerIsUp(cmd.Context(), ssmClient)

--- a/gitpod-network-check/cmd/checks.go
+++ b/gitpod-network-check/cmd/checks.go
@@ -66,7 +66,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 			log.Infof("ℹ️  Found duplicate subnets. We'll test each subnet '%v' only once.", distinctSubnets)
 		}
 
-		log.Infof("ℹ️  Launching EC2 instances in Main subnets")
+		log.Info("ℹ️  Launching EC2 instances in Main subnets")
 		mainInstanceIds, err := launchInstances(cmd.Context(), ec2Client, networkConfig.MainSubnets, instanceProfile.Arn)
 		if err != nil {
 			return err
@@ -74,7 +74,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		log.Infof("ℹ️  Main EC2 instances: %v", mainInstanceIds)
 		InstanceIds = append(InstanceIds, mainInstanceIds...)
 
-		log.Infof("ℹ️  Launching EC2 instances in a Pod subnets")
+		log.Info("ℹ️  Launching EC2 instances in a Pod subnets")
 		podInstanceIds, err := launchInstances(cmd.Context(), ec2Client, networkConfig.PodSubnets, instanceProfile.Arn)
 		if err != nil {
 			return err
@@ -82,7 +82,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		log.Infof("ℹ️  Pod EC2 instances: %v", podInstanceIds)
 		InstanceIds = append(InstanceIds, podInstanceIds...)
 
-		log.Infof("ℹ️  Waiting for EC2 instances to become Running (times out in 4 minutes)")
+		log.Info("ℹ️  Waiting for EC2 instances to become Running (times out in 4 minutes)")
 		runningWaiter := ec2.NewInstanceRunningWaiter(ec2Client, func(irwo *ec2.InstanceRunningWaiterOptions) {
 			irwo.MaxDelay = 15 * time.Second
 			irwo.MinDelay = 5 * time.Second
@@ -91,7 +91,8 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		if err != nil {
 			return fmt.Errorf("❌ Nodes never got Running: %v", err)
 		}
-		log.Infof("ℹ️  Waiting for EC2 instances to become Healthy (times out in 5 minutes)")
+		log.Info("ℹ️  EC2 instances are now Running.")
+		log.Info("ℹ️  Waiting for EC2 instances to become Healthy (times out in 5 minutes)")
 		waitstatusOK := ec2.NewInstanceStatusOkWaiter(ec2Client, func(isow *ec2.InstanceStatusOkWaiterOptions) {
 			isow.MaxDelay = 15 * time.Second
 			isow.MinDelay = 5 * time.Second
@@ -100,7 +101,7 @@ var checkCommand = &cobra.Command{ // nolint:gochecknoglobals
 		if err != nil {
 			return fmt.Errorf("❌ Nodes never got Healthy: %v", err)
 		}
-		log.Info("✅ EC2 Instances are now running successfully")
+		log.Info("✅ EC2 Instances are now healthy/Ok")
 
 		log.Infof("ℹ️  Connecting to SSM...")
 		err = ensureSessionManagerIsUp(cmd.Context(), ssmClient)

--- a/gitpod-network-check/cmd/common.go
+++ b/gitpod-network-check/cmd/common.go
@@ -78,11 +78,11 @@ func cleanup(ctx context.Context, svc *ec2.Client, iamsvc *iam.Client) {
 			itwo.MaxDelay = 15 * time.Second
 			itwo.MinDelay = 5 * time.Second
 		})
-		log.Info("ℹ️  Waiting for EC2 instances to Terminate (times out in 4 minutes)")
-		err = terminateWaiter.Wait(ctx, &ec2.DescribeInstancesInput{InstanceIds: InstanceIds}, *aws.Duration(4 * time.Minute))
+		log.Info("ℹ️  Waiting for EC2 instances to Terminate (times out in 5 minutes)")
+		err = terminateWaiter.Wait(ctx, &ec2.DescribeInstancesInput{InstanceIds: InstanceIds}, *aws.Duration(5 * time.Minute))
 		if err != nil {
 			log.WithError(err).Warn("Failed to wait for instances to terminate")
-			log.Warn("Waiting 2 minutes so network interfaces are deleted")
+			log.Warn("ℹ️  Waiting 2 minutes so network interfaces are deleted")
 			time.Sleep(2 * time.Minute)
 		} else {
 			log.Info("✅ Instances terminated")


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The check must pass if either is true:
* a VPC endpoint with private DNS is enabled in this account
* the api-endpoint parameter has a value and pases the connectivity test (note: this defers private DNS until the cell tries to connect)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1203

## How to test
<!-- Provide steps to test this PR -->
See comments below

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
